### PR TITLE
Add macOS arm64 support and a few improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .vscode
 build
 *.vsix
+.tool-versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "arduino-maker-workshop",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arduino-maker-workshop",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "cpu": [
+        "arm64",
         "x64"
       ],
       "os": [
+        "darwin",
         "win32"
       ],
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,22 @@
         "title": "Upload",
         "category": "Arduino"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Arduino Maker Workshop",
+      "properties": {
+        "arduinoMakerWorkshop.arduinoCLI.executable": {
+          "type": "string",
+          "default": "arduino-cli",
+          "description": "Executable filename for the arduino-cli."
+        },
+        "arduinoMakerWorkshop.arduinoCLI.installPath": {
+          "type": "string",
+          "default": "",
+          "description": "File system path to where the arduino-cli is located."
+        }
+      }
+    }
   },
   "extensionDependencies": [
     "ms-vscode.vscode-serial-monitor",

--- a/package.json
+++ b/package.json
@@ -102,9 +102,11 @@
     "vite": "^6.0.3"
   },
   "os": [
+    "darwin",
     "win32"
   ],
   "cpu": [
+    "arm64",
     "x64"
   ],
   "dependencies": {

--- a/src/VueWebviewPanel.ts
+++ b/src/VueWebviewPanel.ts
@@ -6,6 +6,7 @@ import { arduinoCLI, arduinoExtensionChannel, arduinoProject, changeTheme, loadA
 
 const usb = require('usb').usb;
 const path = require('path');
+const os = require('os');
 
 export class VueWebviewPanel {
 
@@ -17,12 +18,14 @@ export class VueWebviewPanel {
     }
     private constructor(panel: WebviewPanel, extensionUri: Uri) {
         this._panel = panel;
-        usb.on("attach", () => {
-            this.usbChange();
-        });
-        usb.on("detach", () => {
-            this.usbChange();
-        });
+        if (os.platform() !== 'darwin') {
+            usb.on("attach", () => {
+                this.usbChange();
+            });
+            usb.on("detach", () => {
+                this.usbChange();
+            });
+        }
         // Handle messages from the Vue web application
         this._panel.webview.onDidReceiveMessage(
             (message: WebviewToExtensionMessage) => {

--- a/src/cliArgs.ts
+++ b/src/cliArgs.ts
@@ -1,5 +1,7 @@
 import { arduinoProject } from "./extension";
 
+const path = require('path');
+
 const configCommandArduino: string = 'config';
 const dumpOption: string = 'dump';
 const jsonOutputArduino: string = '--json';
@@ -253,7 +255,7 @@ export class CLIArguments {
             command.push(arduinoProject.getProgrammer());
         }
         command.push(`${inputDirOptionArduino}`);
-        command.push(arduinoProject.getProjectPath() + '/' + arduinoProject.getOutput());
+        command.push(path.join(arduinoProject.getProjectPath(), arduinoProject.getOutput()));
         command.push(arduinoProject.getProjectPath());
         return command;
     }
@@ -270,7 +272,7 @@ export class CLIArguments {
             compileCommand.push(`${arduinoProject.getBoard()}`);
         }
         compileCommand.push(`${buildPathArduino}`);
-        compileCommand.push(arduinoProject.getProjectPath() + '\\' + arduinoProject.getOutput());
+        compileCommand.push(path.join(arduinoProject.getProjectPath(), arduinoProject.getOutput()));
         compileCommand.push(arduinoProject.getProjectPath());
         if (jsonOutput) {
             compileCommand.push(`${jsonOutputArduino}`);


### PR DESCRIPTION
* Enable macOS arm64 support. Bundled the current latest `arduino-cli` executable.
* Add settings page for the extension so that we can specify the Arduino install path and executable.
* Prefer `arduino-cli` specified via extension settings, followed by system-wide `arduino-cli`, fall back to bundled executable if neither one is available.