### PR TITLE
Add minimal multi-root workspace support via Explorer context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,8 +115,22 @@
         "command": "arduinoMakerWorkshop.clearCache",
         "title": "Arduino Maker Workshop: Clear CLI Cache",
         "category": "Arduino"
+      },
+      {
+        "command": "arduinoMakerWorkshop.addSubfolderToWorkspace",
+        "title": "Add as Active Workspace Folder",
+        "category": "Arduino"
       }
     ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "arduinoMakerWorkshop.addSubfolderToWorkspace",
+          "when": "explorerResourceIsFolder",
+          "group": "2_workspace"
+        }
+      ]
+    },
     "configuration": {
       "title": "Arduino Maker Workshop",
       "properties": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ export const profileActivateCommandName: string = 'activateBuildProfile';
 export const profileDeactivateCommandName: string = 'deactivateBuildProfile';
 export const decodeBacktraceCommandName: string = 'arduinoMakerWorkshop.decodeEsp32Backtrace';
 export const clearCacheCommandName: string = 'arduinoMakerWorkshop.clearCache';
+export const addSubfolderToWorkspaceCommandName: string = 'arduinoMakerWorkshop.addSubfolderToWorkspace';
 
 export const compileStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
 export const compileStatusBarNotExecuting: string = "$(check) Compile";
@@ -97,6 +98,8 @@ async function ensureSerialMonitorAvailable(): Promise<void> {
 }
 
 export async function activate(context: ExtensionContext) {
+	context.subscriptions.push(vsCommandAddSubfolderToWorkspace());
+
 	ensureSerialMonitorAvailable();
 
 	compileOutputView = new CliOutputView(context);
@@ -680,6 +683,59 @@ function vsCommandClearCache(): Disposable {
 			}
 		}
 	});
+}
+
+function vsCommandAddSubfolderToWorkspace(): Disposable {
+	return commands.registerCommand(
+		addSubfolderToWorkspaceCommandName,
+		(selectedUri?: Uri) => {
+			if (!selectedUri) {
+				window.showErrorMessage(
+					'Select a folder in the Explorer first.'
+				);
+				return;
+			}
+
+			const currentFolders = workspace.workspaceFolders ?? [];
+
+			const alreadyFirst =
+				currentFolders.length > 0 &&
+				currentFolders[0].uri.toString() === selectedUri.toString();
+
+			if (alreadyFirst) {
+				window.showInformationMessage(
+					`${path.basename(selectedUri.fsPath)} is already the active workspace folder.`
+				);
+				return;
+			}
+
+			const remainingFolders = currentFolders
+				.filter(
+					(folder) =>
+						folder.uri.toString() !== selectedUri.toString()
+				)
+				.map((folder) => ({
+					uri: folder.uri,
+					name: folder.name
+				}));
+
+			const success = workspace.updateWorkspaceFolders(
+				0,
+				currentFolders.length,
+				{
+					uri: selectedUri,
+					name: path.basename(selectedUri.fsPath)
+				},
+				...remainingFolders
+			);
+
+			if (!success) {
+				window.showErrorMessage(
+					'Could not add the selected folder to the workspace.'
+				);
+			}
+		}
+	);
 }
 
 export function deactivate() { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,6 +132,18 @@ export async function activate(context: ExtensionContext) {
 			context.subscriptions.push(vsCommandDecodeBacktrace(context));
 			context.subscriptions.push(vsCommandClearCache());
 
+			context.subscriptions.push(
+				workspace.onDidChangeWorkspaceFolders(() => {
+					arduinoProject.readConfiguration();
+					arduinoYaml.refreshProjectState();
+					arduinoCLI.setBuildResult(false);
+
+					checkYamlStatus();
+					updateStateCompileUpload();
+					sendBuildProfiles();
+				})
+			);
+
 			compileStatusBarItem.text = compileStatusBarNotExecuting;
 			compileStatusBarItem.command = compileCommandName;
 			context.subscriptions.push(compileStatusBarItem);

--- a/src/sketchProfileManager.ts
+++ b/src/sketchProfileManager.ts
@@ -20,6 +20,14 @@ export class SketchProfileManager {
         this.yamlInActiveState = path.join(arduinoProject.getProjectPath(), YAML_FILENAME);
         this.yamlInInactiveState = path.join(arduinoProject.getProjectPath(), YAML_FILENAME_INACTIVE);
     }
+
+    public refreshProjectState(): void {
+        this.yamlInActiveState = path.join(arduinoProject.getProjectPath(), YAML_FILENAME);
+        this.yamlInInactiveState = path.join(arduinoProject.getProjectPath(), YAML_FILENAME_INACTIVE);
+        this.resetActiveProfileCache();
+        this.clearError();
+    }
+
     private clearError() {
         this.lastError = "";
     }


### PR DESCRIPTION
Hi,

I teach microcontroller programming, and I usually keep many Arduino sketches together in a single repository.

I noticed that you experimented with multi-root workspace support around last Christmas. Those changes appeared to require fairly broad modifications, and it seems that this approach was not pursued further.

This patch takes a deliberately minimal approach. It formalizes the workaround I used successfully with Arduino Maker Workshop during the last school year:

1.) Open the repository containing all sketches in VS Code.
2.) Add the desired sketch subfolder as a separate workspace folder.
3.) Move that folder to the first position in the workspace.

Because Arduino Maker Workshop uses the first workspace folder as the active project, the extension then works normally with the selected sketch.

The patch adds a new command to the Explorer folder context menu:

"Add as Active Workspace Folder"

The command behaves as follows:

- If the selected folder is not yet part of the workspace, it is added as the first workspace folder.
- If it is already part of the workspace, it is moved to the first position.
- If it is already the first workspace folder, the workspace remains unchanged.

The command is intentionally independent of Arduino CLI initialization, since it only manages the VS Code workspace.

I tested all three cases in the VS Code Extension Development Host on Windows. The extension compiles successfully, and lint reports no errors.

For an example repository demonstrating the intended workflow, see:

https://github.com/BerndDonner/Microcontrollertechnik

Best regards,
Bernd Donner