### PR TITLE
Fix serial monitor settings persistence

### DIFF
--- a/src/ArduinoProject.ts
+++ b/src/ArduinoProject.ts
@@ -12,6 +12,7 @@ export const COMPILE_RESULT_FILE: string = "compile_result.json";
 const ARDUINO_SETTINGS: string = "arduino.json";
 export const ARDUINO_SKETCH_EXTENSION: string = ".ino";
 const ARDUINO_DEFAULT_OUTPUT: string = "build";
+const ARDUINO_CONFIGURATION_SCHEMA_VERSION: number = 1;
 const SOURCE_EXTENSIONS = ['.ino', '.cpp', '.h', '.hpp', '.c', '.cc', '.cxx'];
 
 export enum UPLOAD_READY_STATUS {
@@ -41,6 +42,7 @@ export class ArduinoProject {
             vscode.window.showErrorMessage('No workspace available, open a workspace by using the File > Open Folder... menu, and then selecting a folder');
         }
         this.configJson = {
+            schemaVersion: ARDUINO_CONFIGURATION_SCHEMA_VERSION,
             port: "", configuration: "", output: ARDUINO_DEFAULT_OUTPUT, board: "", programmer: "", useProgrammer: false,
             optimize_for_debug: false, configurationRequired: false, compile_profile: "",
             monitorPortSettings: getMonitorPortSettingsDefault()
@@ -184,6 +186,15 @@ export class ArduinoProject {
             try {
                 const configContent = fs.readFileSync(this.arduinoConfigurationPath, 'utf-8');
                 let configJson = JSON.parse(configContent);
+
+                // Files without a schema version use the legacy, unversioned format.
+                if (configJson.schemaVersion === undefined) {
+                    const legacyMonitorPortSettings = configJson.monitorPortSettings?.settings;
+                    if (legacyMonitorPortSettings !== undefined) {
+                        configJson.monitorPortSettings = legacyMonitorPortSettings;
+                    }
+                    configJson.schemaVersion = ARDUINO_CONFIGURATION_SCHEMA_VERSION;
+                }
 
                 if (configJson.monitorPortSettings === undefined) {
                     configJson.monitorPortSettings = getMonitorPortSettingsDefault();

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -116,6 +116,7 @@ export interface PortSettings {
 
 // Arduino Project Configuration
 export interface ArduinoProjectConfiguration {
+  schemaVersion: number;
   port: string;
   configuration: string;
   configurationRequired: boolean;

--- a/vue_webview/public/mock/arduino_configuration.json
+++ b/vue_webview/public/mock/arduino_configuration.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 1,
   "port": "",
   "configuration": "UploadSpeed=921600,USBMode=hwcdc,CDCOnBoot=default,MSCOnBoot=default,DFUOnBoot=default,UploadMode=default,CPUFreq=240,FlashMode=qio,FlashSize=4M,PartitionScheme=default,DebugLevel=none,PSRAM=disabled,LoopCore=1,EventsCore=1,EraseFlash=none,JTAGAdapter=default,ZigbeeMode=default",
   "output": "build",

--- a/vue_webview/public/mock/arduino_configuration_newsketch.json
+++ b/vue_webview/public/mock/arduino_configuration_newsketch.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 1,
   "port": "",
   "configuration": "",
   "output": "build",

--- a/vue_webview/src/components/Home.vue
+++ b/vue_webview/src/components/Home.vue
@@ -38,13 +38,19 @@ const serialPortsAvailable = computed(() => getAvailablePorts(store).map((p: any
   return { ...p, value, title };
 }));
 
-function updatePortSettings(settings: PortSettings) {
+function updatePortSettings(
+  { settings }: {
+    settings: PortSettings;
+    profile_name: string;
+  }
+) {
   store.sendMessage({
     command: ARDUINO_MESSAGES.SET_MONITOR_PORT_SETTINGS,
     errorMessage: "",
     payload: JSON.stringify(settings),
-  });;
+  });
 }
+
 function changeStatusBuildProfile() {
   const status = store.sketchProject?.buildProfileStatus;
   switch (status) {

--- a/vue_webview/src/components/Home.vue
+++ b/vue_webview/src/components/Home.vue
@@ -267,12 +267,6 @@ watch(selectedBuildProfile, (newProfile) => {
 });
 
 
-watch(monitorPortSettings, (newMonitorPortSettings) => {
-  store.sendMessage({
-    command: ARDUINO_MESSAGES.SET_MONITOR_PORT_SETTINGS, errorMessage: "", payload: JSON.stringify(newMonitorPortSettings)
-  });
-});
-
 watch(() => store.projectInfo?.monitorPortSettings, (newMonitorPortSettings) => {
   getStoredMonitorPortSettings();
 });


### PR DESCRIPTION
`SerialMonitorSettings.vue` emits an object containing `settings` and `profile_name`, but `Home.vue` serialized the complete object as `monitorPortSettings`.

This caused an additional `settings` level in `arduino.json`, so values such as the baud rate were not restored correctly.

This PR:

* serializes only the actual `settings` object
* removes a redundant shallow watcher in `Home.vue`

Tested by changing the baud rate and reloading the VS Code window.
