### PR TITLE
Handle WebviewPanel disconnects during multi-root workspace changes

### DIFF
--- a/src/VueWebviewPanel.ts
+++ b/src/VueWebviewPanel.ts
@@ -1229,6 +1229,10 @@ export class VueWebviewPanel {
         changeTheme(window.activeColorTheme.kind);
     }
 
+    public static disposeCurrentPanel(): void {
+        VueWebviewPanel.currentPanel?.dispose();
+    }
+
     public static refreshActiveProject(): void {
         const projectStatus = arduinoProject.getStatus();
         VueWebviewPanel.sendMessage({

--- a/src/VueWebviewPanel.ts
+++ b/src/VueWebviewPanel.ts
@@ -1,6 +1,7 @@
 import { commands, ConfigurationTarget, Disposable, Webview, WebviewPanel, window, Uri, ViewColumn, ExtensionContext, Position, Range, Selection, workspace } from "vscode";
 import { getUri } from "./utilities/getUri";
 import { getNonce } from "./utilities/getNonce";
+import { WebviewConnectionHeartbeat } from "./webviewConnectionHeartbeat";
 import { ARDUINO_ERRORS, ARDUINO_MESSAGES, BacktraceDecodeFrame, BacktraceDecodeResult, ESP32_PARTITION_BUILDER_BASE_URL, PROFILES_STATUS, SketchProjectFile, WebviewToExtensionMessage } from './shared/messages';
 import { arduinoCLI, arduinoExtensionChannel, arduinoProject, arduinoYaml, changeTheme, compile, loadArduinoConfiguration, openExample, shouldCheckForUpdates, shouldDetectPorts, updateStateCompileUpload } from "./extension";
 
@@ -393,6 +394,7 @@ export class VueWebviewPanel {
         );
 
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+        this._disposables.push(new WebviewConnectionHeartbeat(this._panel.webview));
         this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);
         arduinoExtensionChannel.appendLine("Arduino Web view ready");
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,10 +98,19 @@ async function ensureSerialMonitorAvailable(): Promise<void> {
 }
 
 export async function activate(context: ExtensionContext) {
+	let resolveExtensionReady!: (ready: boolean) => void;
+	const extensionReady = new Promise<boolean>((resolve) => {
+		resolveExtensionReady = resolve;
+	});
+
 	context.subscriptions.push(
 		window.registerWebviewPanelSerializer('vueWebview', {
-			deserializeWebviewPanel(webviewPanel) {
-				VueWebviewPanel.restore(webviewPanel, context);
+			async deserializeWebviewPanel(webviewPanel) {
+				if (await extensionReady) {
+					VueWebviewPanel.restore(webviewPanel, context);
+				} else {
+					webviewPanel.dispose();
+				}
 			}
 		})
 	);
@@ -277,16 +286,19 @@ export async function activate(context: ExtensionContext) {
 			sourceWatcher.onDidDelete((uri) => invalidateBuild(uri.fsPath));
 			context.subscriptions.push(sourceWatcher);
 
+			resolveExtensionReady(true);
 		} else {
 			arduinoProject.setStatus(ARDUINO_ERRORS.CONFIG_FILE_PROBLEM);
 			const configError = arduinoCLI.lastCLIError() || 'Arduino CLI configuration is not valid';
 			arduinoExtensionChannel.appendLine(`${configError}`);
+			resolveExtensionReady(false);
 			return;
 		}
 	} else {
 		arduinoProject.setStatus(ARDUINO_ERRORS.CLI_NOT_WORKING);
 		const cliError = arduinoCLI.lastCLIError() || 'Arduino CLI is not available';
 		arduinoExtensionChannel.appendLine(`${cliError}`);
+		resolveExtensionReady(false);
 		return;
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,6 +98,14 @@ async function ensureSerialMonitorAvailable(): Promise<void> {
 }
 
 export async function activate(context: ExtensionContext) {
+	context.subscriptions.push(
+		window.registerWebviewPanelSerializer('vueWebview', {
+			deserializeWebviewPanel(webviewPanel) {
+				VueWebviewPanel.restore(webviewPanel, context);
+			}
+		})
+	);
+
 	context.subscriptions.push(vsCommandAddSubfolderToWorkspace());
 
 	ensureSerialMonitorAvailable();
@@ -131,14 +139,6 @@ export async function activate(context: ExtensionContext) {
 			context.subscriptions.push(vsCommandDeactivateBuildProfiles());
 			context.subscriptions.push(vsCommandDecodeBacktrace(context));
 			context.subscriptions.push(vsCommandClearCache());
-			context.subscriptions.push(
-				window.registerWebviewPanelSerializer('vueWebview', {
-					deserializeWebviewPanel(webviewPanel) {
-						VueWebviewPanel.restore(webviewPanel, context);
-					}
-				})
-			);
-
 			context.subscriptions.push(
 				workspace.onDidChangeWorkspaceFolders(() => {
 					arduinoProject.readConfiguration();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -750,10 +750,6 @@ function vsCommandAddSubfolderToWorkspace(): Disposable {
 					name: folder.name
 				}));
 
-			// This command can restart the extension host without closing the webview.
-			// Close the panel while the current extension host still owns it.
-			VueWebviewPanel.disposeCurrentPanel();
-
 			const success = workspace.updateWorkspaceFolders(
 				0,
 				currentFolders.length,
@@ -764,7 +760,11 @@ function vsCommandAddSubfolderToWorkspace(): Disposable {
 				...remainingFolders
 			);
 
-			if (!success) {
+			if (success) {
+				// This command can restart the extension host without closing the webview.
+				// Close the panel only after VS Code accepts the workspace change.
+				VueWebviewPanel.disposeCurrentPanel();
+			} else {
 				window.showErrorMessage(
 					'Could not add the selected folder to the workspace.'
 				);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -738,6 +738,10 @@ function vsCommandAddSubfolderToWorkspace(): Disposable {
 					name: folder.name
 				}));
 
+			// This command can restart the extension host without closing the webview.
+			// Close the panel while the current extension host still owns it.
+			VueWebviewPanel.disposeCurrentPanel();
+
 			const success = workspace.updateWorkspaceFolders(
 				0,
 				currentFolders.length,
@@ -757,5 +761,8 @@ function vsCommandAddSubfolderToWorkspace(): Disposable {
 	);
 }
 
-export function deactivate() { }
+export function deactivate() {
+	// Best-effort cleanup for extension-host restarts initiated outside this extension.
+	VueWebviewPanel.disposeCurrentPanel();
+}
 

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -568,5 +568,6 @@ export const ARDUINO_MESSAGES = {
   // Misc commands
   OPEN_LIBRARY: 'openExample',
   CHANGE_THEME_COLOR: "changeThemeColor",
+  EXTENSION_HEARTBEAT: "extensionHeartbeat",
   LOG_DEBUG: "logDebug"
 };

--- a/src/webviewConnectionHeartbeat.ts
+++ b/src/webviewConnectionHeartbeat.ts
@@ -1,0 +1,32 @@
+import { Disposable, Webview } from "vscode";
+import { ARDUINO_MESSAGES } from "./shared/messages";
+
+/**
+ * Workaround for microsoft/vscode#70656.
+ *
+ * VS Code can restart the extension host while keeping a WebviewPanel open.
+ * The surviving webview is then disconnected from the new extension host, and
+ * WebviewPanelSerializer is not invoked. Remove this class when VS Code offers
+ * a native lifecycle option such as microsoft/vscode#225979.
+ */
+export class WebviewConnectionHeartbeat implements Disposable {
+    private static readonly INTERVAL_MS = 1_000;
+    private readonly timer: NodeJS.Timeout;
+
+    public constructor(private readonly webview: Webview) {
+        this.postHeartbeat();
+        this.timer = setInterval(() => this.postHeartbeat(), WebviewConnectionHeartbeat.INTERVAL_MS);
+    }
+
+    public dispose(): void {
+        clearInterval(this.timer);
+    }
+
+    private postHeartbeat(): void {
+        void this.webview.postMessage({
+            command: ARDUINO_MESSAGES.EXTENSION_HEARTBEAT,
+            errorMessage: "",
+            payload: ""
+        });
+    }
+}

--- a/vue_webview/src/App.vue
+++ b/vue_webview/src/App.vue
@@ -3,12 +3,19 @@ import Toolbox from './components/Toolbox.vue';
 import { onMounted, onUnmounted } from 'vue';
 import { useVsCodeStore } from './stores/useVsCodeStore';
 import Theme from './components/Theme.vue';
+import DisconnectedView from './components/DisconnectedView.vue';
+import { useExtensionConnection } from './composables/useExtensionConnection';
 import { ARDUINO_MESSAGES, THEME_COLOR } from '@shared/messages';
 
 const store = useVsCodeStore();
+const { connectionState, handleConnectionMessage } = useExtensionConnection();
 
 function handleMessageFromVsCode(event: MessageEvent) {
   const message = event.data; // The message sent from the extension
+
+  if (handleConnectionMessage(message)) {
+    return;
+  }
 
   // Use the store action to handle the message
   if (import.meta.env.DEV) {
@@ -34,9 +41,15 @@ onUnmounted(() => {
 <template>
   <Theme></Theme>
   <v-app v-if="store.currentTheme">
-    <Toolbox></Toolbox>
-    <v-main>
-      <router-view></router-view>
+    <DisconnectedView v-if="connectionState === 'disconnected'"></DisconnectedView>
+    <template v-else-if="connectionState === 'connected'">
+      <Toolbox></Toolbox>
+      <v-main>
+        <router-view></router-view>
+      </v-main>
+    </template>
+    <v-main v-else class="d-flex align-center justify-center">
+      <v-progress-circular indeterminate></v-progress-circular>
     </v-main>
   </v-app>
   <v-progress-linear v-else color="grey" indeterminate></v-progress-linear>

--- a/vue_webview/src/components/DisconnectedView.vue
+++ b/vue_webview/src/components/DisconnectedView.vue
@@ -1,0 +1,11 @@
+<template>
+  <v-main class="d-flex align-center justify-center">
+    <v-container class="text-center" style="max-width: 640px">
+      <v-icon icon="mdi-connection" size="64" class="mb-4"></v-icon>
+      <h1 class="text-h5 mb-3">Extension connection lost</h1>
+      <p class="text-body-1">
+        Close and reopen the Arduino Maker Workshop view to reconnect.
+      </p>
+    </v-container>
+  </v-main>
+</template>

--- a/vue_webview/src/composables/useExtensionConnection.ts
+++ b/vue_webview/src/composables/useExtensionConnection.ts
@@ -1,0 +1,38 @@
+import { onMounted, onUnmounted, ref } from "vue";
+import { ARDUINO_MESSAGES } from "@shared/messages";
+
+export type ExtensionConnectionState = "waiting" | "connected" | "disconnected";
+
+const DISCONNECT_TIMEOUT_MS = 5_000;
+
+/**
+ * Webview-side half of the workaround for microsoft/vscode#70656.
+ * Keep the lifecycle workaround isolated so it can be deleted when VS Code
+ * provides native auto-close behavior for extension-host restarts.
+ */
+export function useExtensionConnection() {
+    const state = ref<ExtensionConnectionState>(import.meta.env.DEV ? "connected" : "waiting");
+    let disconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+    function armDisconnectTimer(): void {
+        if (disconnectTimer) clearTimeout(disconnectTimer);
+        disconnectTimer = setTimeout(() => { state.value = "disconnected"; }, DISCONNECT_TIMEOUT_MS);
+    }
+
+    function handleMessage(message: { command?: string }): boolean {
+        if (message.command !== ARDUINO_MESSAGES.EXTENSION_HEARTBEAT) return false;
+        state.value = "connected";
+        armDisconnectTimer();
+        return true;
+    }
+
+    onMounted(() => {
+        if (!import.meta.env.DEV) armDisconnectTimer();
+    });
+
+    onUnmounted(() => {
+        if (disconnectTimer) clearTimeout(disconnectTimer);
+    });
+
+    return { connectionState: state, handleConnectionMessage: handleMessage };
+}


### PR DESCRIPTION
This issue only affects the extension's multi-root workspace workflow.

Changing, removing, or reordering the first workspace folder can restart the VS Code extension host without reloading the window. An existing WebviewPanel may then remain visible while losing its connection to the extension host.

This is a known VS Code issue: microsoft/vscode#70656.

This PR:

* closes the WebviewPanel before “Add as Active Workspace Folder” changes the multi-root workspace
* adds a small heartbeat fallback for workspace changes that are performed outside the extension, such as drag-and-drop reordering
* replaces the stale UI with a disconnected message when the extension stops responding
* registers the existing WebviewPanel serializer early during activation

The serializer was tested separately. It restores the panel after `Developer: Reload Window`, but it is not called when changing the first folder of a multi-root workspace causes an extension host restart.

The heartbeat is therefore a workaround for this specific VS Code lifecycle gap. Its implementation is isolated so it can be removed easily if VS Code adds native support, such as the proposed `autoCloseWhenDispose` option from microsoft/vscode#225979.

Tested with:

* “Add as Active Workspace Folder”
* drag-and-drop reordering of multi-root workspace folders
* removing or changing the first workspace folder
* `Developer: Reload Window`
